### PR TITLE
Fix for error: Method not found: 'ButtonTheme.bar'

### DIFF
--- a/lib/utils/my_alert_dialog.dart
+++ b/lib/utils/my_alert_dialog.dart
@@ -136,7 +136,7 @@ class MyAlertDialog<T> extends StatelessWidget {
 
     if (actions != null) {
       if (isDividerEnabled) children.add(divider);
-      children.add(new ButtonTheme.bar(
+      children.add(new ButtonBarTheme(
         child: new ButtonBar(
           children: actions,
         ),


### PR DESCRIPTION
```
../../../flutter/.pub-cache/hosted/pub.dartlang.org/country_pickers-1.3.0/lib/utils/my_alert_dialog.dart:139:36: Error: Method not found: 'ButtonTheme.bar'.
      children.add(new ButtonTheme.bar(
                                   ^^^
```